### PR TITLE
Add artsy OSS banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,28 @@ tslint bar.ts
 ```
 
 Note that `baz.json` would be skipped because it doesn't match with any patterns in the configuration.
+
+## About Artsy
+
+<a href="https://www.artsy.net/">
+  <img align="left" src="https://avatars2.githubusercontent.com/u/546231?s=200&v=4"/>
+</a>
+
+This project is the work of engineers at [Artsy][footer_website], the world's
+leading and largest online art marketplace and platform for discovering art.
+One of our core [Engineering Principles][footer_principles] is being [Open
+Source by Default][footer_open] which means we strive to share as many details
+of our work as possible.
+
+You can learn more about this work from [our blog][footer_blog] and by following
+[@ArtsyOpenSource][footer_twitter] or explore our public data by checking out
+[our API][footer_api]. If you're interested in a career at Artsy, read through
+our [job postings][footer_jobs]!
+
+[footer_website]: https://www.artsy.net/
+[footer_principles]: culture/engineering-principles.md
+[footer_open]: culture/engineering-principles.md#open-source-by-default
+[footer_blog]: https://artsy.github.io/
+[footer_twitter]: https://twitter.com/ArtsyOpenSource
+[footer_api]: https://developers.artsy.net/
+[footer_jobs]: https://www.artsy.net/jobs


### PR DESCRIPTION
Adds the artsy banner!
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.0.3-canary.5.85.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/lint-changed@3.0.3-canary.5.85.0
  # or 
  yarn add @artsy/lint-changed@3.0.3-canary.5.85.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
