### PR TITLE
Lint only files changed since branch off of master

### DIFF
--- a/src/lint-changed.ts
+++ b/src/lint-changed.ts
@@ -72,9 +72,9 @@ const checkMasterForChangedFiles = async () => {
 /**
  * Checks for  files that have changed since origin/master
  */
-const checkFeatureBranchForChangedFiles = async () => {
+const checkFeatureBranchForChangedFiles = async (branch: string) => {
   const [changedFilesError, changedFilesList] = await to(
-    getChangedFiles(`origin/master`)
+    getChangedFiles(`master...${branch}`)
   );
   if (changedFilesError || changedFilesList === undefined) {
     error(
@@ -107,7 +107,7 @@ export async function lintChanged() {
   let changedFiles: string[] =
     branch === "master"
       ? await checkMasterForChangedFiles()
-      : await checkFeatureBranchForChangedFiles();
+      : await checkFeatureBranchForChangedFiles(branch);
 
   // Exit early if no files have changed
   if (changedFiles.length === 0) {


### PR DESCRIPTION
@bhoggard identified an issue where if the branch is out of date with master then `lint-changed` will lint all files that are different since origin/master... which could include a _lot_ of files (many of which may not exist). To avoid that I've updated how `checkFeatureBranchForChangedFiles` works. Now it takes a branch name and issues

```bash
git diff --name-only master...${branch}
```

This will return only the files that have changed since the given branch was created from master. 