### PR TITLE
Only lint existing files, limit concurrency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "await-to-js": "^2.1.1",
     "kleur": "^3.0.3",
     "micromatch": "^4.0.2",
-    "p-each-series": "^2.1.0"
+    "p-each-series": "^2.1.0",
+    "p-limit": "^2.2.2"
   },
   "devDependencies": {
     "@artsy/auto-config": "1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -66,6 +66,18 @@ p-each-series@^2.1.0:
   resolved "https://registry.yarnpkg.com/p-each-series/-/p-each-series-2.1.0.tgz#961c8dd3f195ea96c747e636b262b800a6b1af48"
   integrity sha512-ZuRs1miPT4HrjFa+9fRfOFXxGJfORgelKV9f9nNOWw2gl6gVsRaVDOQP0+MI0G0wGKns1Yacsu0GjOFbTK0JFQ==
 
+p-limit@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.2.tgz#61279b67721f5287aa1c13a9a7fbbc48c9291b1e"
+  integrity sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==
+  dependencies:
+    p-try "^2.0.0"
+
+p-try@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
+  integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
+
 picomatch@^2.0.5:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.1.tgz#21bac888b6ed8601f831ce7816e335bc779f0a4a"


### PR DESCRIPTION
This PR does two things:

1. Uses `p-limit` to limit the number of concurrent checks at any one time (to ensure we don't overload cpu/memory constraints of CI). I'd like to follow up with different optimizations...
2. Filters out an non-existing files so that they're not sent through the checks. 