### PR TITLE
Feature/add branch config parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ _This package is inspired heavily by [lint-staged](https://github.com/okonet/lin
 
 We waste a lot of time of CI time doing unnecessary tasks. Why lint _all_ your files when git already tells you which files have changed? **@artsy/lint-changed** helps by only running lint tags for the files that have changed since master (when not on master) or since the last tag (if you _are_ on master).
 
-## Configuration
+## Basic Configuration
 
 Add a `lint-changed` key to your `package.json` with a pattern of files to match and the command or commands you'd like to run for each changed file. Each command will be ran for every changed file that matches it's pattern.
 
@@ -34,6 +34,22 @@ tslint bar.ts
 ```
 
 Note that `baz.json` would be skipped because it doesn't match with any patterns in the configuration.
+
+## Configuring base branch
+
+By default Artsy will use `master` as the base branch for detecting changes. In case your default branch is not `master` you can let
+Artsy know what branch to use as a base branch.
+
+```json
+{
+  "lint-changed-branch": "development",
+  "lint-changed": {
+    "*.js": ["eslint", "prettier -c"],
+    "*.ts": "tslint"
+  }
+}
+
+```
 
 ## About Artsy
 

--- a/src/lint-changed.ts
+++ b/src/lint-changed.ts
@@ -26,7 +26,8 @@ const filterOutNonExistentFiles = (files: string[]) =>
   files.filter((file) => fs.existsSync(path.join(process.cwd(), file)));
 
 interface PkgConfig {
-  ["lint-changed-branch"]?: string;
+  ["lint-changed-base-branch"]?: string;
+  ["lint-changed-release-branch"]?: string;
   ["lint-changed"]?: {
     [glob: string]: string | string[];
   };
@@ -119,10 +120,17 @@ export async function lintChanged() {
   const baseBranch = pkg["lint-changed-base-branch"] || "master";
   const releaseBranch = pkg["lint-changed-release-branch"] || "master";
 
-  // Warn if branch is not specified
+  // Warn if basebranch is not specified
   if (!lintConfig) {
     warn(
-      "No `lint-changed-branch` found in package.json, falling back to 'master'"
+      "No `lint-changed-base-branch` found in package.json, falling back to 'master'"
+    );
+  }
+
+  // Warn if releasebranch is not specified
+  if (!lintConfig) {
+    warn(
+      "No `lint-changed-release-branch` found in package.json, falling back to 'master'"
     );
   }
 

--- a/src/lint-changed.ts
+++ b/src/lint-changed.ts
@@ -50,7 +50,7 @@ const git = (args: string) => runCommand(`git ${args}`);
 const getBranch = () => git("rev-parse --abbrev-ref HEAD");
 const getLastTag = () => git("describe --tags --abbrev=0 HEAD^");
 const getMergeBase = (baseBranch: string) =>
-  git("merge-base HEAD ${baseBranch}");
+  git(`merge-base HEAD ${baseBranch}`);
 
 const getChangedFiles = (event: string) =>
   git(`diff --name-only ${event}`).then((r) =>

--- a/src/lint-changed.ts
+++ b/src/lint-changed.ts
@@ -89,11 +89,14 @@ const checkReleaseBranchForChangedFiles = async () => {
 /**
  * Checks for  files that have changed since baseBranch
  */
-const checkFeatureBranchForChangedFiles = async (baseBranch: string) => {
-  log("Checking for files that have changed since base branch");
+const checkFeatureBranchForChangedFiles = async (
+  baseBranch: string,
+  branch: string
+) => {
+  log("Checking for files that have changed on ${branch} since ${baseBranch}");
   const mergeBase = await getMergeBase(baseBranch);
   const [changedFilesError, changedFilesList] = await to(
-    getChangedFiles(`${baseBranch} ${mergeBase}`)
+    getChangedFiles(`${branch} ${mergeBase}`)
   );
   if (changedFilesError || changedFilesList === undefined) {
     error(
@@ -143,7 +146,7 @@ export async function lintChanged() {
   let changedFiles: string[] =
     branch === releaseBranch
       ? await checkReleaseBranchForChangedFiles()
-      : await checkFeatureBranchForChangedFiles(baseBranch);
+      : await checkFeatureBranchForChangedFiles(baseBranch, branch);
 
   // Exit early if no files have changed
   if (changedFiles.length === 0) {

--- a/src/lint-changed.ts
+++ b/src/lint-changed.ts
@@ -60,8 +60,8 @@ const getChangedFiles = (event: string) =>
 /**
  * Checks for files that have changed since the last tag on the base branch
  */
-const checkBaseBranchForChangedFiles = async () => {
-  log("Checking for files that have changed since last tag on base branch");
+const checkReleaseBranchForChangedFiles = async () => {
+  log("Checking for files that have changed since last tag on release branch");
   const [tagFetchError, lastTag] = await to(getLastTag());
   if (tagFetchError) {
     error(`Unable to retrieve last tag:\n${tagFetchError}`);
@@ -116,7 +116,8 @@ const checkFeatureBranchForChangedFiles = async (
 
 export async function lintChanged() {
   const lintConfig = pkg["lint-changed"];
-  const baseBranch = pkg["lint-changed-branch"] || "master";
+  const baseBranch = pkg["lint-changed-base-branch"] || "master";
+  const releaseBranch = pkg["lint-changed-release-branch"] || "master";
 
   // Warn if branch is not specified
   if (!lintConfig) {
@@ -135,8 +136,8 @@ export async function lintChanged() {
 
   // Determine changed files based on branch
   let changedFiles: string[] =
-    branch === baseBranch
-      ? await checkBaseBranchForChangedFiles()
+    branch === releaseBranch
+      ? await checkReleaseBranchForChangedFiles()
       : await checkFeatureBranchForChangedFiles(baseBranch, branch);
 
   // Exit early if no files have changed

--- a/src/lint-changed.ts
+++ b/src/lint-changed.ts
@@ -89,12 +89,9 @@ const checkReleaseBranchForChangedFiles = async () => {
 /**
  * Checks for  files that have changed since baseBranch
  */
-const checkFeatureBranchForChangedFiles = async (
-  baseBranch: string,
-  branch: string
-) => {
+const checkFeatureBranchForChangedFiles = async (baseBranch: string) => {
   log("Checking for files that have changed since base branch");
-  const mergeBase = getMergeBase(baseBranch);
+  const mergeBase = await getMergeBase(baseBranch);
   const [changedFilesError, changedFilesList] = await to(
     getChangedFiles(`${baseBranch} ${mergeBase}`)
   );
@@ -146,7 +143,7 @@ export async function lintChanged() {
   let changedFiles: string[] =
     branch === releaseBranch
       ? await checkReleaseBranchForChangedFiles()
-      : await checkFeatureBranchForChangedFiles(baseBranch, branch);
+      : await checkFeatureBranchForChangedFiles(baseBranch);
 
   // Exit early if no files have changed
   if (changedFiles.length === 0) {

--- a/src/lint-changed.ts
+++ b/src/lint-changed.ts
@@ -93,8 +93,12 @@ const checkFeatureBranchForChangedFiles = async (
   baseBranch: string,
   branch: string
 ) => {
-  log("Checking for files that have changed on ${branch} since ${baseBranch}");
-  const mergeBase = await getMergeBase(baseBranch);
+  log(`Checking for files that have changed on ${branch} since ${baseBranch}`);
+  const [mergeBaseError, mergeBase] = await to(getMergeBase(baseBranch));
+  if (mergeBaseError) {
+    error(`Unable to retrieve merge base:\n${mergeBaseError}`);
+    process.exit(1);
+  }
   const [changedFilesError, changedFilesList] = await to(
     getChangedFiles(`${branch} ${mergeBase}`)
   );


### PR DESCRIPTION
fixes: #22 

This introduces a new configurable field `lint-changed-branch` that can be used to define what branch to base the changes off. It defaults to `master` so this is not a breaking change.

See README for updated documentation.
